### PR TITLE
Remove build from startup script #53

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run server
+web: node server

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "publish": "node run publish",
     "publish:debug": "node run publish --debug",
     "deploy": "gulp deploy",
-    "server": "npm run build:prod && node server",
+    "heroku-postbuild": "npm run build:prod",
     "start": "node run"
   }
 }


### PR DESCRIPTION
Heroku was failing on startup due to timeout during build. `heroku-postbuild` should occur before the 'starting' phase of heroku deploy, thus circumventing the timeout.
