### PR TITLE
Revert breaking major change #53

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "front-matter": "2.1.0",
     "gulp": "3.9.1",
     "highlight.js": "9.7.0",
-    "history": "4.3.0",
+    "history": "3.2.1",
     "http-proxy-middleware": "0.17.2",
     "identity-obj-proxy": "3.0.0",
     "jest": "16.0.2",


### PR DESCRIPTION
In the sprit of following the history API spec, history npm module has removed support for query parsing in version 4. Reverting until a better place for query parsing is found.
